### PR TITLE
HighTouchSensitivity [2/2]: Add Settings preference

### DIFF
--- a/src/com/android/settings/inputmethod/InputMethodAndLanguageSettings.java
+++ b/src/com/android/settings/inputmethod/InputMethodAndLanguageSettings.java
@@ -66,6 +66,7 @@ import com.android.settings.search.Indexable;
 import com.android.settings.search.SearchIndexableRaw;
 
 import cyanogenmod.hardware.CMHardwareManager;
+import cyanogenmod.providers.CMSettings;
 
 import java.text.Collator;
 import java.util.ArrayList;
@@ -414,10 +415,14 @@ public class InputMethodAndLanguageSettings extends SettingsPreferenceFragment
         }
         if (preference == mStylusIconEnabled) {
             Settings.System.putInt(getActivity().getContentResolver(),
-                Settings.System.STYLUS_ICON_ENABLED, mStylusIconEnabled.isChecked() ? 1 : 0);
+                    Settings.System.STYLUS_ICON_ENABLED, mStylusIconEnabled.isChecked() ? 1 : 0);
         } else if (preference == mHighTouchSensitivity) {
+            boolean mHighTouchSensitivityEnable = mHighTouchSensitivity.isChecked();
+            CMSettings.System.putInt(getActivity().getContentResolver(),
+                    CMSettings.System.HIGH_TOUCH_SENSITIVITY_ENABLE,
+                    mHighTouchSensitivityEnable ? 1 : 0);
             return mHardware.set(CMHardwareManager.FEATURE_HIGH_TOUCH_SENSITIVITY,
-                    mHighTouchSensitivity.isChecked());
+                    mHighTouchSensitivityEnable);
         } else if (preference == mTouchscreenHovering) {
             return mHardware.set(CMHardwareManager.FEATURE_TOUCH_HOVERING,
                     mTouchscreenHovering.isChecked());


### PR DESCRIPTION
 * Allows the HighTouchSensitivity (Glove mode)
   value to be saved in the CMSettings provider

 * Can be used in a device specific service to handle
   the Glove mode in a way closer to the device's vendor

 * Changes include :
     android_packages_apps_Settings
     cm_platform_sdk

Change-Id: If57bbfddbed1324fcb8488ef5a03ff242a128ba3
Signed-off-by: AdrianDC <radian.dc@gmail.com>